### PR TITLE
Revive Ruby spider after last platform changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 80F70E11F0F0D5F10CB20E62
 RUN gem install bundler
 WORKDIR /app/
 ADD Gemfile* /app/
+RUN bundle config --global silence_root_warning 1
 RUN bundle install
 
 RUN apt-get install -y python
-ENTRYPOINT ["/app/entrypoint"]
 
 ADD . /app
+RUN ln -s /app/start-crawl /usr/sbin/start-crawl
+RUN ln -s /app/list-spiders /usr/sbin/list-spiders

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-ruby '2.2.3'
+ruby '2.2.5'
 gem "anemone"

--- a/entrypoint
+++ b/entrypoint
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-if [ $1 = "start-crawl" ]; then
-    echo "Running crawler"
-    /app/crawler.rb
-else
-    echo "Wrong params"
-fi

--- a/list-spiders
+++ b/list-spiders
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo argenteam

--- a/spiders.rb
+++ b/spiders.rb
@@ -22,7 +22,7 @@ class ArgenteamSpider
     return if not job_data
 
     job_key, job_auth = job_data["key"], job_data["auth"]
-    uri = URI.join("#{shub_storage}", "#{prefix}/#{job_key}/")
+    uri = URI.join("#{shub_storage}", "#{prefix}/#{job_key}")
     uri.query = URI.encode_www_form(params)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = (uri.scheme == "https")

--- a/spiders.rb
+++ b/spiders.rb
@@ -36,7 +36,7 @@ class ArgenteamSpider
     if response.is_a?(Net::HTTPSuccess)
         logger.info "<-- HS #{response.code} #{response.uri} #{response.body}"
     else
-        logger.warning "HS bad response #{response}"
+        logger.warn "HS bad response #{response}"
     end
   end
 

--- a/spiders.rb
+++ b/spiders.rb
@@ -63,7 +63,14 @@ class ArgenteamSpider
            :description => description,
            :images => [image]},
           {:start => offset})
-
+        upload('requests',
+          {:url => page.url.to_s,
+           :status => page.code,
+           :rs => page.body.length,
+           :duration => page.response_time,
+           :method => "GET",
+           :time => Time.now.to_i},
+          {:start => offset})
         offset += 1
         exit if offset > 10
       end

--- a/start-crawl
+++ b/start-crawl
@@ -1,0 +1,2 @@
+#!/bin/sh
+/app/crawler.rb


### PR DESCRIPTION
The PR includes the following changes:
- added list-spider entrypoint
- dropped custom decode_env logic with plain json use
- other multiple platform-related fixes
- add an example for sending requests

Review, please. Let me know if you have any other ideas how to make it more clean and presentable, I'm going to write a short doc describing main corner cases and most important things to consider.
